### PR TITLE
Use crypton bounds

### DIFF
--- a/.github/workflows/stack.yaml
+++ b/.github/workflows/stack.yaml
@@ -1,0 +1,45 @@
+name: Stack
+
+on:
+    pull_request:
+    push:
+      branches:
+      - master
+
+jobs:
+  build:
+    name: CI
+    runs-on: ${{ matrix.os }}
+    env:
+      STACK_ROOT: ${{ github.workspace }}/.stack
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest,
+          # windows-latest # TODO add windows support
+        ]
+        resolver: [nightly, lts-19, lts-20]
+
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.stack
+            ${{ github.workspace }}/.stack
+          key: ${{ runner.os }}-${{ matrix.resolver }}-haskell-${{ hashFiles('stack.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.resolver }}-haskell-
+
+      - name: Build and run tests
+        shell: bash
+        run: |
+            set -ex
+            curl -sSL https://get.haskellstack.org/ | sh -s - -f
+            stack build --fast --no-terminal --resolver=${{ matrix.resolver }}
+            # stack test --fast --no-terminal --resolver=${{ matrix.resolver }} # TODO fix test suite

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+flags:
+  tcp-streams: {}
+packages:
+  - "."
+extra-deps: []
+resolver: lts-20

--- a/tcp-streams.cabal
+++ b/tcp-streams.cabal
@@ -38,9 +38,9 @@ library
                     ,   io-streams     >= 1.2 && < 2.0
                     ,   tls            >= 1.3 && < 2.0
                     ,   data-default-class
-                    ,   x509           >= 1.5 && < 2.0
-                    ,   x509-system    >= 1.5 && < 2.0
-                    ,   x509-store     >= 1.5 && < 2.0
+                    ,   crypton-x509           >= 1.5 && < 2.0
+                    ,   crypton-x509-system    >= 1.5 && < 2.0
+                    ,   crypton-x509-store     >= 1.5 && < 2.0
                     ,   pem           
 
   ghc-options:    -Wall


### PR DESCRIPTION
since the maintainers of cryptonite decided to rename their package we need to fix all downstream dependencies.